### PR TITLE
Adds migrations for Prisma and fix autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
 		"@witnessco/client": "^0.4.2",
 		"axios": "^1.7.2",
 		"googleapis": "^137.1.0",
+		"lodash": "^4.17.21",
 		"moment": "^2.30.1",
 		"next": "14.2.3",
 		"next-auth": "^4.24.7",
@@ -37,6 +38,7 @@
 	},
 	"//": "prisma 5.11.0 needed for Prisma Client Python",
 	"devDependencies": {
+		"@types/lodash": "^4.17.10",
 		"@types/node": "^20.12.12",
 		"@types/react": "^18.3.3",
 		"@types/react-dom": "^18.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       googleapis:
         specifier: ^137.1.0
         version: 137.1.0
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
       moment:
         specifier: ^2.30.1
         version: 2.30.1
@@ -57,6 +60,9 @@ importers:
         specifier: ^3.23.8
         version: 3.23.8
     devDependencies:
+      '@types/lodash':
+        specifier: ^4.17.10
+        version: 4.17.10
       '@types/node':
         specifier: ^20.12.12
         version: 20.12.12
@@ -788,6 +794,9 @@ packages:
 
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
+
+  '@types/lodash@4.17.10':
+    resolution: {integrity: sha512-YpS0zzoduEhuOWjAotS6A5AVCva7X4lVlYLF0FYHAY9sdraBfnatttHItlWeZdGhuEkf+OzMNg2ZYAx8t+52uQ==}
 
   '@types/node@20.12.12':
     resolution: {integrity: sha512-eWLDGF/FOSPtAvEqeRAQ4C8LSA7M1I7i0ky1I8U7kD1J5ITyW3AsRhQrKVoWf5pFKZ2kILsEGJhsI9r93PYnOw==}
@@ -3575,6 +3584,8 @@ snapshots:
       '@types/unist': 2.0.10
 
   '@types/json-schema@7.0.15': {}
+
+  '@types/lodash@4.17.10': {}
 
   '@types/node@20.12.12':
     dependencies:

--- a/prisma/migrations/20240906162204_add_domain_to_index/migration.sql
+++ b/prisma/migrations/20240906162204_add_domain_to_index/migration.sql
@@ -1,0 +1,2 @@
+-- CreateIndex
+CREATE INDEX "DomainSelectorPair_domain_idx" ON "DomainSelectorPair"("domain");

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -20,6 +20,8 @@ model DomainSelectorPair {
   lastRecordUpdate DateTime?
   records          DkimRecord[]
   sourceIdentifier String
+
+  @@index([domain])
 }
 
 enum KeyType {

--- a/src/app/actions.ts
+++ b/src/app/actions.ts
@@ -8,7 +8,6 @@ export async function autocomplete(query: string) {
   if (!query) {
     return [];
   }
-  console.log(query);
 
   // if (query.length < 3) {
   //   let dsps = await prisma.domainSelectorPair.findMany({
@@ -89,7 +88,6 @@ export async function autocomplete(query: string) {
       domain: true,
     },
   });
-  // console.log(dsps);
 
   const results = dsps.map((d) => d.domain);
 

--- a/src/components/DomainSearchResults.tsx
+++ b/src/components/DomainSearchResults.tsx
@@ -3,55 +3,79 @@ import { RecordWithSelector } from "@/lib/db";
 import { SelectorResult } from "./SelectorResult";
 import React, { useEffect } from "react";
 import { findKeysPaginated } from "@/app/actions";
-import { useInView } from 'react-intersection-observer'
+import { useInView } from "react-intersection-observer";
 
 interface DomainSearchResultProps {
-	domainQuery: string | undefined;
-	initialRecords: RecordWithSelector[];
+  domainQuery: string | undefined;
+  initialRecords: RecordWithSelector[];
 }
 
 export const DomainSearchResults: React.FC<DomainSearchResultProps> = ({ domainQuery, initialRecords }) => {
-	const [cursor, setCursor] = React.useState<number | null>(initialRecords[initialRecords.length - 1]?.id);
-	const [records, setRecords] = React.useState(initialRecords);
-	const { ref: inViewElement, inView } = useInView();
+  const [cursor, setCursor] = React.useState<number | null>(initialRecords[initialRecords.length - 1]?.id);
+  const [records, setRecords] = React.useState(initialRecords);
+  const { ref: inViewElement, inView } = useInView();
 
-	useEffect(() => {
-		setCursor(initialRecords[initialRecords.length - 1]?.id);
-		setRecords(initialRecords);
-	}, [domainQuery]);
+  useEffect(() => {
+    setCursor(initialRecords[initialRecords.length - 1]?.id);
+    setRecords(initialRecords);
+  }, [domainQuery]);
 
-	useEffect(() => {
-		if (inView) {
-			loadMore()
-		}
-	}, [inView])
+  useEffect(() => {
+    if (inView) {
+      loadMore();
+    }
+  }, [inView]);
 
-	async function loadMore() {
-		if (!cursor) {
-			return;
-		}
-		let newRecords = domainQuery ? await findKeysPaginated(domainQuery, cursor) : [];
-		let lastCursor = newRecords[newRecords.length - 1]?.id;
-		setCursor(lastCursor);
-		setRecords([...records, ...newRecords]);
-	}
+  async function loadMore() {
+    if (!cursor) {
+      return;
+    }
+    console.log("cursor", cursor);
+    let newRecords = domainQuery ? await findKeysPaginated(domainQuery, cursor) : [];
+    console.log("newRecords", newRecords);
+    if (!newRecords.length) {
+      // If no new records are found, stop further loading
+      setCursor(null);
+      return;
+    }
 
-	if (!domainQuery) {
-		return <div>Enter a search term</div>
-	};
-	if (!records?.length) {
-		return <div>No records found for "{domainQuery}"</div>
-	}
-	return (
-		<div>
-			<p>Search results for <b>{domainQuery}</b></p>
-			<div>
-				{records.map((record) => (
-					<SelectorResult key={record.id} record={record} />
-				))}
-			</div>
-			{!cursor && <p>No more records</p>}
-			<div ref={inViewElement} />
-		</div>
-	);
+    let lastCursor = newRecords[newRecords.length - 1]?.id;
+
+    if (lastCursor === cursor) {
+      setCursor(null);
+      return;
+    }
+
+    // Combine records but filter out duplicates using their unique `id`
+    const uniqueRecords = [...records, ...newRecords].reduce((acc, record) => {
+      if (!acc.find((r) => r.id === record.id)) {
+        acc.push(record);
+      }
+      return acc;
+    }, [] as RecordWithSelector[]);
+
+    setCursor(lastCursor);
+    setRecords(uniqueRecords);
+  }
+
+  if (!domainQuery) {
+    return <div>Enter a search term</div>;
+  }
+  if (!records?.length) {
+    return <div>No records found for "{domainQuery}"</div>;
+  }
+  return (
+    <div>
+      <p>
+        Search results for <b>{domainQuery}</b>
+      </p>
+      <div>
+        {records.map((record) => (
+          <SelectorResult key={record.id} record={record} />
+        ))}
+      </div>
+      {!cursor && <p>No more records</p>}
+      <div ref={inViewElement} />
+    </div>
+  );
 };

--- a/src/components/DomainSearchResults.tsx
+++ b/src/components/DomainSearchResults.tsx
@@ -30,9 +30,9 @@ export const DomainSearchResults: React.FC<DomainSearchResultProps> = ({ domainQ
     if (!cursor) {
       return;
     }
-    console.log("cursor", cursor);
+
     let newRecords = domainQuery ? await findKeysPaginated(domainQuery, cursor) : [];
-    console.log("newRecords", newRecords);
+
     if (!newRecords.length) {
       // If no new records are found, stop further loading
       setCursor(null);
@@ -46,7 +46,6 @@ export const DomainSearchResults: React.FC<DomainSearchResultProps> = ({ domainQ
       return;
     }
 
-    // Combine records but filter out duplicates using their unique `id`
     const uniqueRecords = [...records, ...newRecords].reduce((acc, record) => {
       if (!acc.find((r) => r.id === record.id)) {
         acc.push(record);

--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -35,6 +35,7 @@ export const SearchInput: React.FC<SearchFormProps> = ({ domainQuery }) => {
 				disablePortal
 				onInputChange={inputChanged}
 				onChange={onChange}
+				filterOptions={(x) => x}				
 				options={searchResults}
 				sx={{ width: 300 }}
 				freeSolo


### PR DESCRIPTION
This PR should add dashes to URLs during searches, but it causes an out of memory error on the instance. I think this is due to empty queries hitting the database, but I'm not sure and it requires some more logging. You can test the staging deploy on: https://archive-staging-prove-email.onrender.com