### PR TITLE
fix: filter empty public keys

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -41,6 +41,11 @@ export async function findRecords(domainQuery: string): Promise<RecordWithSelect
 						}
 					}
 				]
+			},
+			value: {
+				not: {
+					equals: "p="
+				}
 			}
 		},
 		include: {


### PR DESCRIPTION
> https://archive.prove.email/api/key?domain=info.coinbase.com

```
[
  {
    "domain": "info.coinbase.com",
    "selector": "utmvq47cidwb6eo5dijoyabype4gxcbw",
    "firstSeenAt": "2024-02-19T05:47:32.558Z",
    "lastSeenAt": "2024-09-26T18:09:59.811Z",
    "value": "p=MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQDiSQzJOwrZcEypHOgGQBup/uoO/S4ordj2fsNedLefe6rQ9Dhb5R/XUdPDyM6pn/YhVqgbvX3ygWJ49qHjcWTWXC0fUNClyic1wby4LIH3i1QcAnqL2AZpRTj2xQ89kQDVymAKrv2vTCNdgNRPjIbWtxvJ2cRzZ7oOS9fFrnRvAwIDAQAB"
  },
  {
    "domain": "info.coinbase.com",
    "selector": "utmvq47cidwb6eo5dijoyabype4gxcbw",
    "firstSeenAt": "2024-10-05T05:42:45.294Z",
    "lastSeenAt": "2024-11-22T21:44:19.591Z",
    "value": "p="
  }
]
```

currently returns records with empty keys

