### PR TITLE
fixes #133

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -6,7 +6,7 @@ const cspValue = [
   "frame-ancestors 'none'",
   "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
   "img-src 'self' https://authjs.dev/ data:", // https://authjs.dev/ for images during the login flow
-  "connect-src 'self' https://*.alchemy.com", // https://*.alchemy.com used by Witness
+  "connect-src 'self' https://*.alchemy.com https://*.prove.email", // https://*.alchemy.com used by Witness https://*.prove.email used by API
 ];
 
 const nextConfig = {


### PR DESCRIPTION
Hey this commit fixes #133. The api explores was not working due to the currenlty set CSP.

I have fixed the CSP to include "https://*.prove.email" as well.

![image](https://github.com/user-attachments/assets/22620f0a-c9c1-49fa-8044-cac6f3bd9134)

![image](https://github.com/user-attachments/assets/edd4d16b-fb50-4b75-9c98-f3d8662260d3)

