### PR TITLE
Print the timestamp during mail analysis.

### DIFF
--- a/src/app/api/gmail/route.ts
+++ b/src/app/api/gmail/route.ts
@@ -57,7 +57,11 @@ async function handleMessage(
     let addResult = await addDomainSelectorPair(domain, selector, "api");
 
     let domainSelectorPair = { domain, selector };
-    resultArray.push({ addResult, domainSelectorPair });
+    resultArray.push({
+      addResult,
+      domainSelectorPair,
+      mailTimestamp: internalDate?.toString(),
+    });
   }
   return resultArray;
 }
@@ -65,6 +69,7 @@ async function handleMessage(
 type AddDspResult = {
   addResult: AddResult;
   domainSelectorPair: DomainAndSelector;
+  mailTimestamp?: String;
 };
 
 export type GmailResponse = {

--- a/src/app/upload_gmail/page.tsx
+++ b/src/app/upload_gmail/page.tsx
@@ -237,8 +237,9 @@ export default function Page() {
 			for (const addDspResult of response.data.addDspResults) {
 				const pair = addDspResult.domainSelectorPair;
 				const pairString = JSON.stringify(pair);
+				const timestamp = addDspResult.mailTimestamp;
 				if (!uploadedPairs.has(pairString)) {
-					logmsg('new pair found: ' + JSON.stringify(pair));
+					logmsg('new pair found: ' + JSON.stringify({ ...pair, timestamp }));
 					if (addDspResult.addResult.added) {
 						logmsg(`${pairString} was added to the archive`);
 						setAddedPairs(addedPairs => addedPairs + 1);

--- a/src/app/upload_tsv/page.tsx
+++ b/src/app/upload_tsv/page.tsx
@@ -55,13 +55,19 @@ export default function Page() {
 		logmsg(`starting upload to ${addDspApiUrl}`);
 		for (let i = 0; i < domainSelectorPairs.length; i++) {
 			let dsp = domainSelectorPairs[i];
-			logmsg(`uploading (${i + 1}/${domainSelectorPairs.length}) ${JSON.stringify(dsp)}`);
+			let timestamp = ''
+			const selectorParts = dsp.selector?.split(':') || [];
+			if (selectorParts.length > 1) {
+				timestamp = selectorParts.slice(1).join(':')
+			}
+			dsp = { domain: dsp.domain, selector: dsp.selector.split(':')[0] };
+			logmsg(`uploading (${i + 1}/${domainSelectorPairs.length}) ${JSON.stringify({ ...dsp, timestamp })}`);
 			try {
 				let response = await axios.post<AddDspResponse>(addDspApiUrl, dsp as AddDspRequest);
 				await update();
 				console.log('upsert response', response);
 				if (response.data.addResult?.added) {
-					logmsg(`${JSON.stringify(dsp)} was added to the archive`);
+					logmsg(`${JSON.stringify({ ...dsp, timestamp })} was added to the archive`);
 					setAddedPairs(addedPairs => addedPairs + 1);
 				}
 			}

--- a/src/util/mbox_scraper.py
+++ b/src/util/mbox_scraper.py
@@ -5,18 +5,21 @@ import mailbox
 from dkim_util import decode_dkim_tag_value_list
 
 
-def add_to_dict(dct: dict[str, list[str]], domain: str, selector: str):
+def add_to_dict(dct: dict[str, list[str]], domain: str, selector: str, date: str):
 	if (not selector) or (not domain):
 		return
 	if domain not in dct:
 		dct[domain] = []
-	if selector not in dct[domain]:
-		dct[domain].append(selector)
+	entry = f'{selector}:{date}'
+	if entry not in dct[domain]:
+		dct[domain].append(entry)
+
 
 
 def get_domain_selectors(outputDict: dict[str, list[str]], mboxFile: str):
 	print(f'processing {mboxFile}', file=sys.stderr)
 	for message in mailbox.mbox(mboxFile):
+		date = message['Date']         
 		dkimSignatures = message.get_all('DKIM-Signature')
 		if not dkimSignatures:
 			continue
@@ -24,7 +27,7 @@ def get_domain_selectors(outputDict: dict[str, list[str]], mboxFile: str):
 			dkimRecord = decode_dkim_tag_value_list(dkimSignature)
 			domain = dkimRecord['d']
 			selector = dkimRecord['s']
-			add_to_dict(outputDict, domain, selector)
+			add_to_dict(outputDict, domain, selector, date)
 
 
 def main():

--- a/src/util/pst_scraper.py
+++ b/src/util/pst_scraper.py
@@ -25,13 +25,16 @@ dsps: set[str] = set()
 def parse_header(data: str):
 	h = email.parser.HeaderParser().parsestr(data)
 	dkim_fields = h.get_all('DKIM-Signature')
+	email_date = h.get('Date')
 	if not dkim_fields:
 		return
 	for dkim_field in dkim_fields:
 		dkimRecord = decode_dkim_tag_value_list(dkim_field)
 		domain = dkimRecord['d']
 		selector = dkimRecord['s']
-		dsps.add(f'{domain}\t{selector}')
+		formatted_date = email_date.strip()
+		descriptor = f"{selector}:{formatted_date}"
+		dsps.add(f'{domain}\t{descriptor}')
 
 
 def parse_message(msg):


### PR DESCRIPTION
The PR prints a timestamp during mail analysis and prints it to the LogConsole on the `/upload_gmail` and `/upload_tsv` pages. Additionally, it updates the `.mbox to .tsv` and `.pst to .tsv` parsers to include the date timestamp in the TSV file along with the selector which is then used to display timestamps on the LogConsole on the `/upload_tsv` page.