### PR TITLE
fix: /api/key cache bypass

### DIFF
--- a/src/app/api/key/route.ts
+++ b/src/app/api/key/route.ts
@@ -1,4 +1,4 @@
-import { findRecords } from "@/lib/db";
+import { findRecordsWithCache } from "@/lib/db";
 import { type NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { RateLimiterMemory } from "rate-limiter-flexible";
@@ -14,7 +14,7 @@ export type DomainSearchResults = {
   value: string;
 };
 
-const rateLimiter = new RateLimiterMemory({ points: 1000, duration: 1 });
+const rateLimiter = new RateLimiterMemory({ points: 200, duration: 60 });
 
 export async function GET(request: NextRequest) {
   try {
@@ -31,14 +31,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json("missing domain parameter", { status: 400 });
     }
 
-    let records = await findRecords(domainName);
-
-    // Filter by selector if provided
-    if (selector) {
-      records = records.filter(
-        (record) => record.domainSelectorPair.selector === selector
-      );
-    }
+    const records = await findRecordsWithCache(domainName, selector ?? undefined);
 
     const result: DomainSearchResults[] = records.map((record) => ({
       domain: record.domainSelectorPair.domain,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -267,9 +267,14 @@ export async function findRecordsWithCache(
       return result;
       
     } else {
-      // Domain-only path (same detailed logging)
+      // Domain-only path: match exact domain and all subdomains
       const dsps = await prisma.domainSelectorPair.findMany({
-        where: { domain: domainNorm },
+        where: {
+          OR: [
+            { domain: domainNorm },
+            { domain: { endsWith: "." + domainNorm, mode: Prisma.QueryMode.insensitive } },
+          ],
+        },
         select: { id: true, domain: true, selector: true },
       });
       

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -160,11 +160,12 @@ export function axiosErrorMessage(error: any): string {
 }
 
 export async function checkRateLimiter(rateLimiter: RateLimiterMemory, headers: ReadonlyHeaders, consumePoints: number) {
+	// Use the rightmost X-Forwarded-For entry (set by the outermost trusted proxy).
+	// The leftmost entry is attacker-controlled and must not be used.
+	// Falls back to "unknown" so requests without the header are still rate limited.
 	const forwardedFor = headers.get("x-forwarded-for");
-	if (forwardedFor) {
-		const clientIp = forwardedFor.split(',')[0];
-		await rateLimiter.consume(clientIp, consumePoints);
-	}
+	const clientIp = forwardedFor ? forwardedFor.split(",").pop()!.trim() : "unknown";
+	await rateLimiter.consume(clientIp, consumePoints);
 }
 
 export function isValidDate(year: number, month: number, day: number) {


### PR DESCRIPTION
`findRecords` was called instead of `findRecordsWithCache`, causing every
request to run an unindexed full table scan and exhaust the DB connection
pool under load.
Also fixed `checkRateLimiter` silently skipping when
`x-forwarded-for` is absent and switched to rightmost entry to prevent IP
spoofing. Rate limit reduced from 1000/sec to 200/min.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Cached queries now incorporate filters to reduce in-memory work and return related subdomain records more reliably.

* **Rate Limiting Updates**
  * Lower request allowance with a longer throttling window for stricter control.
  * Improved client IP detection behind proxies and more consistent consumption of rate-limit tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->