### PR TITLE
Fix OAuth callback base URL

### DIFF
--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -3,14 +3,24 @@ import { getRequestBaseUrl } from "@/lib/requestBaseUrl";
 import NextAuth from "next-auth";
 import type { NextRequest } from "next/server";
 
-const handler = (request: NextRequest) => {
-	const requestBaseUrl = getRequestBaseUrl(request.headers);
+type NextAuthRouteContext = {
+	params: {
+		nextauth: string[];
+	};
+};
 
-	if (requestBaseUrl) {
-		process.env.NEXTAUTH_URL = requestBaseUrl;
+process.env.AUTH_TRUST_HOST ??= "true";
+
+const handler = (request: NextRequest, context: NextAuthRouteContext) => {
+	const requestBaseUrl = getRequestBaseUrl(request.headers, {
+		allowFallback: false,
+	});
+
+	if (!requestBaseUrl) {
+		return new Response("Untrusted auth host", { status: 400 });
 	}
 
-	return NextAuth(authOptions)(request);
+	return NextAuth(authOptions)(request, context);
 };
 
 export { handler as GET, handler as POST };

--- a/src/app/api/auth/[...nextauth]/route.ts
+++ b/src/app/api/auth/[...nextauth]/route.ts
@@ -1,6 +1,16 @@
-import NextAuth from "next-auth"
 import { authOptions } from "@/app/auth";
+import { getRequestBaseUrl } from "@/lib/requestBaseUrl";
+import NextAuth from "next-auth";
+import type { NextRequest } from "next/server";
 
-const handler = NextAuth(authOptions)
+const handler = (request: NextRequest) => {
+	const requestBaseUrl = getRequestBaseUrl(request.headers);
 
-export { handler as GET, handler as POST }
+	if (requestBaseUrl) {
+		process.env.NEXTAUTH_URL = requestBaseUrl;
+	}
+
+	return NextAuth(authOptions)(request);
+};
+
+export { handler as GET, handler as POST };

--- a/src/app/api/gmail/route.ts
+++ b/src/app/api/gmail/route.ts
@@ -10,6 +10,7 @@ import { processAndStoreEmailSignature } from "@/lib/store_email_signature";
 import { headers } from 'next/headers';
 import { verifyDKIMSignature } from "@zk-email/helpers/dist/dkim";
 import chalk from "chalk";
+import { getGoogleOAuthCallbackUrl } from "@/lib/requestBaseUrl";
 
 async function handleMessage(
   messageId: string,
@@ -130,14 +131,13 @@ async function handleRequest(request: NextRequest) {
     return NextResponse.json("Missing access_token", { status: 403 });
   }
   const headersList = await headers();
-  const host = headersList.get('host');
-  const baseUrl = process.env.NODE_ENV === 'development' ? `http://${host}/api/auth/callback/google` : `https://${host}/api/auth/callback/google`;
+  const redirectUri = getGoogleOAuthCallbackUrl(headersList);
   const clientId = process.env.IS_PULL_REQUEST == "true" ? process.env.PREVIEW_GOOGLE_CLIENT_ID : process.env.GOOGLE_CLIENT_ID || '';
   const clientSecret = process.env.IS_PULL_REQUEST == "true" ? process.env.PREVIEW_GOOGLE_CLIENT_SECRET : process.env.GOOGLE_CLIENT_SECRET;
   const oauth2Client = new google.auth.OAuth2(
     clientId,
     clientSecret,
-    baseUrl,
+    redirectUri,
   );
   const gmail = google.gmail({ version: "v1", auth: oauth2Client });
 

--- a/src/lib/requestBaseUrl.test.ts
+++ b/src/lib/requestBaseUrl.test.ts
@@ -13,16 +13,34 @@ describe("request base URL helpers", () => {
 		);
 	});
 
-	test("uses render preview forwarded headers", () => {
+	test("uses the configured Render preview hostname", () => {
 		const headers = new Headers({
 			"x-forwarded-host": "archive-pr-123.onrender.com",
 			"x-forwarded-proto": "https",
 			host: "internal-render-host",
 		});
 
-		expect(getRequestBaseUrl(headers, { nodeEnv: "production" })).toBe(
-			"https://archive-pr-123.onrender.com",
-		);
+		expect(
+			getRequestBaseUrl(headers, {
+				nodeEnv: "production",
+				renderExternalHostname: "https://archive-pr-123.onrender.com",
+			}),
+		).toBe("https://archive-pr-123.onrender.com");
+	});
+
+	test("does not trust every Render hostname", () => {
+		const headers = new Headers({
+			"x-forwarded-host": "other-app.onrender.com",
+			"x-forwarded-proto": "https",
+		});
+
+		expect(
+			getRequestBaseUrl(headers, {
+				fallbackUrl: "https://archive.zk.email",
+				nodeEnv: "production",
+				renderExternalHostname: "archive-pr-123.onrender.com",
+			}),
+		).toBe("https://archive.zk.email");
 	});
 
 	test("uses http for localhost development", () => {
@@ -42,5 +60,17 @@ describe("request base URL helpers", () => {
 				nodeEnv: "production",
 			}),
 		).toBe("https://archive.zk.email");
+	});
+
+	test("can reject an untrusted host without fallback", () => {
+		const headers = new Headers({ host: "attacker.example" });
+
+		expect(
+			getRequestBaseUrl(headers, {
+				allowFallback: false,
+				fallbackUrl: "https://archive.zk.email/",
+				nodeEnv: "production",
+			}),
+		).toBeUndefined();
 	});
 });

--- a/src/lib/requestBaseUrl.test.ts
+++ b/src/lib/requestBaseUrl.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from "vitest";
+import { getGoogleOAuthCallbackUrl, getRequestBaseUrl } from "./requestBaseUrl";
+
+describe("request base URL helpers", () => {
+	test("uses the archive.zk.email host in production", () => {
+		const headers = new Headers({ host: "archive.zk.email" });
+
+		expect(getRequestBaseUrl(headers, { nodeEnv: "production" })).toBe(
+			"https://archive.zk.email",
+		);
+		expect(getGoogleOAuthCallbackUrl(headers, { nodeEnv: "production" })).toBe(
+			"https://archive.zk.email/api/auth/callback/google",
+		);
+	});
+
+	test("uses render preview forwarded headers", () => {
+		const headers = new Headers({
+			"x-forwarded-host": "archive-pr-123.onrender.com",
+			"x-forwarded-proto": "https",
+			host: "internal-render-host",
+		});
+
+		expect(getRequestBaseUrl(headers, { nodeEnv: "production" })).toBe(
+			"https://archive-pr-123.onrender.com",
+		);
+	});
+
+	test("uses http for localhost development", () => {
+		const headers = new Headers({ host: "localhost:3000" });
+
+		expect(getRequestBaseUrl(headers, { nodeEnv: "development" })).toBe(
+			"http://localhost:3000",
+		);
+	});
+
+	test("falls back when the request host is not trusted", () => {
+		const headers = new Headers({ host: "attacker.example" });
+
+		expect(
+			getRequestBaseUrl(headers, {
+				fallbackUrl: "https://archive.zk.email/",
+				nodeEnv: "production",
+			}),
+		).toBe("https://archive.zk.email");
+	});
+});

--- a/src/lib/requestBaseUrl.ts
+++ b/src/lib/requestBaseUrl.ts
@@ -3,8 +3,10 @@ type HeaderGetter = {
 };
 
 type RequestBaseUrlOptions = {
+	allowFallback?: boolean;
 	fallbackUrl?: string;
 	nodeEnv?: string;
+	renderExternalHostname?: string;
 };
 
 const TRUSTED_HOSTS = new Set([
@@ -14,8 +16,6 @@ const TRUSTED_HOSTS = new Set([
 	"127.0.0.1",
 ]);
 
-const TRUSTED_HOST_SUFFIXES = [".onrender.com"];
-
 function firstHeaderValue(value: string | null): string | undefined {
 	return value?.split(",")[0]?.trim() || undefined;
 }
@@ -24,7 +24,25 @@ function hostnameWithoutPort(host: string): string {
 	return host.replace(/:\d+$/, "").toLowerCase();
 }
 
-function isTrustedHost(host: string, nodeEnv?: string): boolean {
+function configuredHostname(host: string | undefined): string | undefined {
+	if (!host) {
+		return undefined;
+	}
+
+	try {
+		return hostnameWithoutPort(
+			host.includes("://") ? new URL(host).host : host,
+		);
+	} catch {
+		return hostnameWithoutPort(host);
+	}
+}
+
+function isTrustedHost(
+	host: string,
+	nodeEnv?: string,
+	renderExternalHostname?: string,
+): boolean {
 	const hostname = hostnameWithoutPort(host);
 
 	if (TRUSTED_HOSTS.has(hostname)) {
@@ -35,7 +53,7 @@ function isTrustedHost(host: string, nodeEnv?: string): boolean {
 		return true;
 	}
 
-	return TRUSTED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+	return hostname === configuredHostname(renderExternalHostname);
 }
 
 function inferProtocol(host: string, nodeEnv?: string): "http" | "https" {
@@ -64,14 +82,19 @@ export function getRequestBaseUrl(
 	headers: HeaderGetter,
 	options: RequestBaseUrlOptions = {},
 ): string | undefined {
+	const allowFallback = options.allowFallback ?? true;
 	const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
 	const fallbackUrl = options.fallbackUrl ?? process.env.NEXTAUTH_URL;
+	const renderExternalHostname =
+		options.renderExternalHostname ??
+		process.env.RENDER_EXTERNAL_HOSTNAME ??
+		process.env.RENDER_EXTERNAL_URL;
 	const host =
 		firstHeaderValue(headers.get("x-forwarded-host")) ??
 		firstHeaderValue(headers.get("host"));
 
-	if (!host || !isTrustedHost(host, nodeEnv)) {
-		return fallbackUrl?.replace(/\/$/, "");
+	if (!host || !isTrustedHost(host, nodeEnv, renderExternalHostname)) {
+		return allowFallback ? fallbackUrl?.replace(/\/$/, "") : undefined;
 	}
 
 	const protocol = forwardedProtocol(headers) ?? inferProtocol(host, nodeEnv);

--- a/src/lib/requestBaseUrl.ts
+++ b/src/lib/requestBaseUrl.ts
@@ -1,0 +1,89 @@
+type HeaderGetter = {
+	get(name: string): string | null;
+};
+
+type RequestBaseUrlOptions = {
+	fallbackUrl?: string;
+	nodeEnv?: string;
+};
+
+const TRUSTED_HOSTS = new Set([
+	"archive.prove.email",
+	"archive.zk.email",
+	"localhost",
+	"127.0.0.1",
+]);
+
+const TRUSTED_HOST_SUFFIXES = [".onrender.com"];
+
+function firstHeaderValue(value: string | null): string | undefined {
+	return value?.split(",")[0]?.trim() || undefined;
+}
+
+function hostnameWithoutPort(host: string): string {
+	return host.replace(/:\d+$/, "").toLowerCase();
+}
+
+function isTrustedHost(host: string, nodeEnv?: string): boolean {
+	const hostname = hostnameWithoutPort(host);
+
+	if (TRUSTED_HOSTS.has(hostname)) {
+		return true;
+	}
+
+	if (nodeEnv === "development") {
+		return true;
+	}
+
+	return TRUSTED_HOST_SUFFIXES.some((suffix) => hostname.endsWith(suffix));
+}
+
+function inferProtocol(host: string, nodeEnv?: string): "http" | "https" {
+	const hostname = hostnameWithoutPort(host);
+
+	if (
+		nodeEnv === "development" ||
+		hostname === "localhost" ||
+		hostname === "127.0.0.1"
+	) {
+		return "http";
+	}
+
+	return "https";
+}
+
+function forwardedProtocol(
+	headers: HeaderGetter,
+): "http" | "https" | undefined {
+	const protocol = firstHeaderValue(headers.get("x-forwarded-proto"));
+
+	return protocol === "http" || protocol === "https" ? protocol : undefined;
+}
+
+export function getRequestBaseUrl(
+	headers: HeaderGetter,
+	options: RequestBaseUrlOptions = {},
+): string | undefined {
+	const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+	const fallbackUrl = options.fallbackUrl ?? process.env.NEXTAUTH_URL;
+	const host =
+		firstHeaderValue(headers.get("x-forwarded-host")) ??
+		firstHeaderValue(headers.get("host"));
+
+	if (!host || !isTrustedHost(host, nodeEnv)) {
+		return fallbackUrl?.replace(/\/$/, "");
+	}
+
+	const protocol = forwardedProtocol(headers) ?? inferProtocol(host, nodeEnv);
+
+	return `${protocol}://${host}`;
+}
+
+export function getGoogleOAuthCallbackUrl(
+	headers: HeaderGetter,
+	options: RequestBaseUrlOptions = {},
+): string | undefined {
+	const baseUrl = getRequestBaseUrl(headers, options);
+
+	return baseUrl ? `${baseUrl}/api/auth/callback/google` : undefined;
+}


### PR DESCRIPTION
## Summary
- derive the auth and Gmail OAuth callback base URL from trusted request headers
- support `archive.zk.email`, Render preview forwarded hosts, and local development
- fall back to `NEXTAUTH_URL` when the request host is missing or untrusted

Fixes #159

## Tests
- `pnpm install --frozen-lockfile --ignore-scripts`
- `./node_modules/.bin/prisma generate --generator client_js`
- `./node_modules/.bin/vitest run src/lib/requestBaseUrl.test.ts`
- `./node_modules/.bin/biome ci src/lib/requestBaseUrl.ts src/lib/requestBaseUrl.test.ts 'src/app/api/auth/[...nextauth]/route.ts'`
- `./node_modules/.bin/tsc --noEmit`

Note: `./node_modules/.bin/vitest run` still fails on the existing `src/lib/selector_guesser.test.ts` date expectations (`20241122` expected, `20241121` received). The new request-base URL tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Authentication now properly adapts to different deployment environments and hosting configurations, improving reliability across production and preview deployments
  * Enhanced OAuth callback handling for more robust authentication flows

* **Tests**
  * Added comprehensive test coverage for deployment environment validation scenarios

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/archive.zk.email/pull/186)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->