### PR TITLE
Avoid token refresh attempts for public sessions

### DIFF
--- a/src/app/auth.test.ts
+++ b/src/app/auth.test.ts
@@ -1,10 +1,14 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { authOptions } from "./auth";
 
 const jwtCallback = authOptions.callbacks.jwt;
 
 describe("auth jwt callback", () => {
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
 	it("does not refresh tokens for unauthenticated public sessions", async () => {
 		const fetchSpy = vi.spyOn(globalThis, "fetch");
 		const token = {};
@@ -13,8 +17,6 @@ describe("auth jwt callback", () => {
 			token,
 		);
 		expect(fetchSpy).not.toHaveBeenCalled();
-
-		fetchSpy.mockRestore();
 	});
 
 	it("does not retry refresh requests after a refresh failure", async () => {
@@ -29,7 +31,5 @@ describe("auth jwt callback", () => {
 			token,
 		);
 		expect(fetchSpy).not.toHaveBeenCalled();
-
-		fetchSpy.mockRestore();
 	});
 });

--- a/src/app/auth.test.ts
+++ b/src/app/auth.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { authOptions } from "./auth";
+
+const jwtCallback = authOptions.callbacks.jwt;
+
+describe("auth jwt callback", () => {
+	it("does not refresh tokens for unauthenticated public sessions", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		const token = {};
+
+		await expect(jwtCallback({ token, account: undefined })).resolves.toBe(
+			token,
+		);
+		expect(fetchSpy).not.toHaveBeenCalled();
+
+		fetchSpy.mockRestore();
+	});
+
+	it("does not retry refresh requests after a refresh failure", async () => {
+		const fetchSpy = vi.spyOn(globalThis, "fetch");
+		const token = {
+			error: "RefreshAccessTokenError",
+			expires_at: 1,
+			refresh_token: "stale-refresh-token",
+		};
+
+		await expect(jwtCallback({ token, account: undefined })).resolves.toBe(
+			token,
+		);
+		expect(fetchSpy).not.toHaveBeenCalled();
+
+		fetchSpy.mockRestore();
+	});
+});

--- a/src/app/auth.ts
+++ b/src/app/auth.ts
@@ -26,6 +26,9 @@ export const authOptions = {
 				return token
 
 			}
+			else if (!token.refresh_token || !token.expires_at || token.error === "RefreshAccessTokenError") {
+				return token
+			}
 			else if (Date.now() < token.expires_at * 1000) {
 				return token
 			}
@@ -78,4 +81,3 @@ export const authOptions = {
 		}
 	}
 }
-


### PR DESCRIPTION
## Summary
- Skip Google OAuth refresh calls when the JWT callback is handling an unauthenticated/public session with no refresh token or expiry.
- Avoid retrying the refresh endpoint after a previous refresh failure has already marked the token.
- Add regression tests that assert these paths do not call `fetch`.

Fixes #51.

## Validation
- `pnpm install --frozen-lockfile --ignore-scripts`
- `pnpm exec prisma generate --generator client_js`
- `pnpm exec vitest run src/app/auth.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`

Note: `pnpm exec biome check src/app/auth.ts src/app/auth.test.ts` still reports existing style/lint findings in `src/app/auth.ts`; the new `src/app/auth.test.ts` passes Biome check after formatting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced authentication flow to safely handle edge cases when refresh token data is unavailable or already in an error state, preventing unnecessary refresh attempts.

* **Tests**
  * Added test coverage for authentication callbacks to verify correct behavior when token data is missing and error conditions are encountered.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/archive.zk.email/pull/189?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->