### PR TITLE
Try dkim label when fetching DKIM DNS records

### DIFF
--- a/src/lib/utils_server.test.ts
+++ b/src/lib/utils_server.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+	execFileSync: vi.fn(() => "openssl output"),
+	resolve: vi.fn(),
+	setServers: vi.fn(),
+}));
+
+vi.mock("dns", () => ({
+	default: {
+		promises: {
+			Resolver: vi.fn(() => ({
+				resolve: mocks.resolve,
+				setServers: mocks.setServers,
+			})),
+		},
+	},
+}));
+
+vi.mock("node:child_process", () => ({
+	execFileSync: mocks.execFileSync,
+}));
+
+vi.mock("./db", () => ({
+	createDkimRecord: vi.fn(),
+	dspToString: vi.fn(() => "domain selector pair"),
+	prisma: {},
+	recordToString: vi.fn(() => "dkim record"),
+	updateDspTimestamp: vi.fn(),
+}));
+
+vi.mock("./generateWitness", () => ({
+	generateWitness: vi.fn(),
+}));
+
+import { fetchDkimDnsRecord, getDkimDnsQnames } from "./utils_server";
+
+const dkimValue = "v=DKIM1; k=rsa; p=YWJj";
+
+describe("DKIM DNS lookup", () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it("tries _domainkey and dkim qnames", () => {
+		expect(getDkimDnsQnames("example.com", "selector")).toStrictEqual([
+			"selector._domainkey.example.com",
+			"selector.dkim.example.com",
+		]);
+	});
+
+	it("falls back to the dkim label when _domainkey lookup fails", async () => {
+		mocks.resolve.mockImplementation(async (qname: string) => {
+			if (qname === "selector.dkim.example.com") {
+				return [[dkimValue]];
+			}
+			throw new Error("not found");
+		});
+
+		const records = await fetchDkimDnsRecord("example.com", "selector");
+
+		expect(records).toHaveLength(1);
+		expect(records[0]).toMatchObject({
+			domain: "example.com",
+			selector: "selector",
+			value: dkimValue,
+			keyType: "RSA",
+			keyDataBase64: "YWJj",
+		});
+		expect(mocks.resolve).toHaveBeenCalledWith(
+			"selector._domainkey.example.com",
+			"TXT",
+		);
+		expect(mocks.resolve).toHaveBeenCalledWith(
+			"selector.dkim.example.com",
+			"TXT",
+		);
+	});
+
+	it("does not query the dkim label after _domainkey resolves", async () => {
+		mocks.resolve.mockResolvedValue([[dkimValue]]);
+
+		const records = await fetchDkimDnsRecord("example.com", "selector");
+
+		expect(records).toHaveLength(1);
+		expect(records[0].value).toBe(dkimValue);
+		expect(mocks.resolve).toHaveBeenCalledTimes(1);
+		expect(mocks.resolve).not.toHaveBeenCalledWith(
+			"selector.dkim.example.com",
+			"TXT",
+		);
+	});
+});

--- a/src/lib/utils_server.ts
+++ b/src/lib/utils_server.ts
@@ -119,46 +119,61 @@ async function decodeKeyInfo(dkimRecordTsv: string): Promise<{ keyType: KeyType,
 	}
 }
 
-export async function fetchDkimDnsRecord(domain: string, selector: string): Promise<DnsDkimFetchResult[]> {
-	const resolver = new dns.promises.Resolver({ timeout: 2500 });
-	const qname = `${selector}._domainkey.${domain}`;
-	let records;
+export function getDkimDnsQnames(domain: string, selector: string): string[] {
+	return [`${selector}._domainkey.${domain}`, `${selector}.dkim.${domain}`];
+}
+
+async function resolveTxtRecords(resolver: dns.promises.Resolver, qname: string): Promise<string[]> {
 	try {
-		records = (await resolver.resolve(qname, 'TXT')).map(record => record.join(''));
+		return (await resolver.resolve(qname, 'TXT')).map(record => record.join(''));
 	}
 	catch (error) {
 		try {
-			console.log(`[DNS] System DNS failed for ${qname}: ${error}. Falling back to `);
+			console.log(`[DNS] System DNS failed for ${qname}: ${error}. Falling back to public DNS servers.`);
 			resolver.setServers(['8.8.8.8', '8.8.4.4', '1.1.1.1', '1.0.0.1']);
-			records = (await resolver.resolve(qname, 'TXT')).map(record => record.join(''));
+			return (await resolver.resolve(qname, 'TXT')).map(record => record.join(''));
 		}
 		catch (error) {
 			console.log(`[DNS] All DNS servers failed for ${qname}: ${error}.`);
 			return [];
 		}
 	}
-	console.log(`found: ${records.length} records for ${qname}`);
-	const result = [];
-	for (const record of records) {
-		console.log(`record: ${record}`);
-		console.log(`found dns record for ${qname}`);
-		try {
-			const { keyType, keyDataBase64 } = await decodeKeyInfo(record);
-			console.log(`keyType: ${keyType}, keyDataBase64: ${keyDataBase64}`);
-			const dkimRecord: DnsDkimFetchResult = {
-				selector,
-				domain,
-				value: record,
-				timestamp: new Date(),
-				keyType,
-				keyDataBase64
-			};
-			result.push(dkimRecord);
-		}
-		catch (error) {
-			console.log(`error decoding record: ${error}`);
-		}
+}
 
+export async function fetchDkimDnsRecord(domain: string, selector: string): Promise<DnsDkimFetchResult[]> {
+	const resolver = new dns.promises.Resolver({ timeout: 2500 });
+	const result = [];
+	const seenRecords = new Set<string>();
+	for (const qname of getDkimDnsQnames(domain, selector)) {
+		const records = await resolveTxtRecords(resolver, qname);
+		console.log(`found: ${records.length} records for ${qname}`);
+		for (const record of records) {
+			if (seenRecords.has(record)) {
+				continue;
+			}
+			seenRecords.add(record);
+			console.log(`record: ${record}`);
+			console.log(`found dns record for ${qname}`);
+			try {
+				const { keyType, keyDataBase64 } = await decodeKeyInfo(record);
+				console.log(`keyType: ${keyType}, keyDataBase64: ${keyDataBase64}`);
+				const dkimRecord: DnsDkimFetchResult = {
+					selector,
+					domain,
+					value: record,
+					timestamp: new Date(),
+					keyType,
+					keyDataBase64
+				};
+				result.push(dkimRecord);
+			}
+			catch (error) {
+				console.log(`error decoding record: ${error}`);
+			}
+		}
+		if (result.length > 0) {
+			break;
+		}
 	}
 	return result
 }
@@ -204,4 +219,3 @@ export function pubKeyLength(signature: any) {
 	}
 	return minBytes;
 }
-


### PR DESCRIPTION
Refs #158

## Summary
- try the standard `selector._domainkey.domain` DKIM TXT lookup first
- fall back to `selector.dkim.domain` only when no usable `_domainkey` record was found
- add mocked coverage for qname generation, `dkim` fallback, and avoiding extra `dkim` DNS calls after `_domainkey` succeeds

## Tests
- `corepack pnpm exec biome check src/lib/utils_server.test.ts`
- `corepack pnpm exec vitest run src/lib/utils_server.test.ts`
- `corepack pnpm exec tsc --noEmit`
- `git diff --check`
