### PR TITLE
Clear stale domain search results

### DIFF
--- a/src/components/DomainSearchResults.tsx
+++ b/src/components/DomainSearchResults.tsx
@@ -1,112 +1,139 @@
 "use client";
 
-import { findKeysPaginated, findKeysPaginatedModifiedQuery } from "@/app/actions";
+import {
+	findKeysPaginated,
+	findKeysPaginatedModifiedQuery,
+} from "@/app/actions";
 import Loading from "@/app/loading";
 import type { RecordWithSelector } from "@/lib/db";
 import { parseDkimTagList } from "@/lib/utils";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { DomainSearchResultsDisplay } from "./DomainSearchResultsDisplay";
+import { type FlagState, buildInitialSearchState } from "./domainSearchState";
 
 interface DomainSearchResultsProps {
-  domainQuery: string | undefined;
-  isLoading: boolean;
-  setIsLoading: (isLoading: boolean) => void;
+	domainQuery: string | undefined;
+	isLoading: boolean;
+	setIsLoading: (isLoading: boolean) => void;
 }
 
-type flagState = "normal" | "modified" | "stop";
-
 function dkimValueHasPrivateKey(dkimValue: string): boolean {
-  return !!parseDkimTagList(dkimValue).p;
+	return !!parseDkimTagList(dkimValue).p;
 }
 
 async function fetchDomainResults(
-  domainQuery: string | undefined,
-  cursor: number | null,
-  flagState: flagState
-): Promise<{ filteredRecords: RecordWithSelector[]; newFlag: flagState }> {
-  if (!domainQuery) return { filteredRecords: [], newFlag: "stop" };
+	domainQuery: string | undefined,
+	cursor: number | null,
+	flagState: FlagState,
+): Promise<{ filteredRecords: RecordWithSelector[]; newFlag: FlagState }> {
+	if (!domainQuery) return { filteredRecords: [], newFlag: "stop" };
 
-  let fetchedRecords;
+	let fetchedRecords: RecordWithSelector[];
+	let nextFlag = flagState;
 
-  if (flagState === "normal") {
-    fetchedRecords = await findKeysPaginated(domainQuery, cursor);
+	if (flagState === "normal") {
+		fetchedRecords = await findKeysPaginated(domainQuery, cursor);
 
-    if (fetchedRecords.length === 0 && cursor === null) {
-      fetchedRecords = await findKeysPaginatedModifiedQuery(domainQuery, cursor);
-      flagState = "modified";
-    }
-  } else {
-    fetchedRecords = await findKeysPaginatedModifiedQuery(domainQuery, cursor);
-  }
+		if (fetchedRecords.length === 0 && cursor === null) {
+			fetchedRecords = await findKeysPaginatedModifiedQuery(
+				domainQuery,
+				cursor,
+			);
+			nextFlag = "modified";
+		}
+	} else {
+		fetchedRecords = await findKeysPaginatedModifiedQuery(domainQuery, cursor);
+	}
 
-  const filteredRecords = fetchedRecords.filter((record) => dkimValueHasPrivateKey(record.value));
+	const filteredRecords = fetchedRecords.filter((record) =>
+		dkimValueHasPrivateKey(record.value),
+	);
 
-  return { filteredRecords, newFlag: flagState };
+	return { filteredRecords, newFlag: nextFlag };
 }
 
-function DomainSearchResults({ domainQuery, isLoading, setIsLoading }: DomainSearchResultsProps) {
-  const [records, setRecords] = useState<Map<number, RecordWithSelector>>(new Map());
-  const [cursor, setCursor] = useState<number | null>(null);
-  const [flag, setFlag] = useState<flagState>("normal");
+function DomainSearchResults({
+	domainQuery,
+	isLoading,
+	setIsLoading,
+}: DomainSearchResultsProps) {
+	const [records, setRecords] = useState<Map<number, RecordWithSelector>>(
+		new Map(),
+	);
+	const [cursor, setCursor] = useState<number | null>(null);
+	const [flag, setFlag] = useState<FlagState>("normal");
+	const previousFlag = useRef(flag);
 
-  const loadRecords = useCallback(async (domainQuery: string | undefined) => {
-    const { filteredRecords, newFlag } = await fetchDomainResults(domainQuery, null, "normal");
+	const loadRecords = useCallback(
+		async (domainQuery: string | undefined) => {
+			const { filteredRecords, newFlag } = await fetchDomainResults(
+				domainQuery,
+				null,
+				"normal",
+			);
+			const initialState = buildInitialSearchState(filteredRecords, newFlag);
 
-    if (filteredRecords.length === 0) {
-      setFlag("stop");
-      setIsLoading(false);
-      return;
-    }
+			setFlag(initialState.flag);
+			setRecords(initialState.records);
+			setCursor(initialState.cursor);
+			setIsLoading(false);
+		},
+		[setIsLoading],
+	);
 
-    const newRecordsMap = new Map(records);
-    filteredRecords.forEach((record) => newRecordsMap.set(record.id, record));
+	useEffect(() => {
+		setIsLoading(true);
+		loadRecords(domainQuery);
+	}, [domainQuery, loadRecords, setIsLoading]);
 
-    setFlag(newFlag);
-    setRecords(newRecordsMap);
-    setCursor(filteredRecords[filteredRecords.length - 1]?.id);
-    setIsLoading(false);
-  }, []);
+	const loadMore = useCallback(async () => {
+		if (flag === "stop" || (!cursor && flag === "normal")) return;
 
-  useEffect(() => {
-    setIsLoading(true);
-    loadRecords(domainQuery);
-  }, [domainQuery]);
+		const { filteredRecords } = await fetchDomainResults(
+			domainQuery,
+			cursor,
+			flag,
+		);
 
-  useEffect(() => {
-    loadMore();
-  }, [flag]);
+		const lastCursor = filteredRecords[filteredRecords.length - 1]?.id;
 
-  async function loadMore() {
-    if (flag === "stop" || (!cursor && flag === "normal")) return;
+		if (filteredRecords.length === 0 || lastCursor === cursor) {
+			// If no new records are found, stop further loading
+			setCursor(null);
+			setFlag((oldFlag) => (oldFlag === "normal" ? "modified" : "stop"));
+			return;
+		}
 
-    const { filteredRecords } = await fetchDomainResults(domainQuery, cursor, flag);
+		setRecords((currentRecords) => {
+			const updatedRecordsMap = new Map(currentRecords);
+			for (const record of filteredRecords) {
+				if (!updatedRecordsMap.has(record.id)) {
+					updatedRecordsMap.set(record.id, record);
+				}
+			}
+			return updatedRecordsMap;
+		});
 
-    const lastCursor = filteredRecords[filteredRecords.length - 1]?.id;
+		setCursor(lastCursor);
+	}, [cursor, domainQuery, flag]);
 
-    if (filteredRecords.length === 0 || lastCursor === cursor) {
-      // If no new records are found, stop further loading
-      setCursor(null);
-      setFlag((oldFlag) => (oldFlag === "normal" ? "modified" : "stop"));
-      return;
-    }
+	useEffect(() => {
+		if (previousFlag.current === flag) return;
 
-    const updatedRecordsMap = new Map(records);
+		previousFlag.current = flag;
+		loadMore();
+	}, [flag, loadMore]);
 
-    filteredRecords.forEach((record) => {
-      if (!updatedRecordsMap.has(record.id)) {
-        updatedRecordsMap.set(record.id, record);
-      }
-    });
-
-    setCursor(lastCursor);
-    setRecords(updatedRecordsMap);
-  }
-
-  return isLoading ? (
-    <Loading />
-  ) : (
-    <DomainSearchResultsDisplay records={records} domainQuery={domainQuery} loadMore={loadMore} cursor={cursor} />
-  );
+	return isLoading ? (
+		<Loading />
+	) : (
+		<DomainSearchResultsDisplay
+			records={records}
+			domainQuery={domainQuery}
+			loadMore={loadMore}
+			cursor={cursor}
+		/>
+	);
 }
 
 export default DomainSearchResults;

--- a/src/components/DomainSearchResults.tsx
+++ b/src/components/DomainSearchResults.tsx
@@ -7,7 +7,7 @@ import {
 import Loading from "@/app/loading";
 import type { RecordWithSelector } from "@/lib/db";
 import { parseDkimTagList } from "@/lib/utils";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { DomainSearchResultsDisplay } from "./DomainSearchResultsDisplay";
 import { type FlagState, buildInitialSearchState } from "./domainSearchState";
 
@@ -62,29 +62,46 @@ function DomainSearchResults({
 	);
 	const [cursor, setCursor] = useState<number | null>(null);
 	const [flag, setFlag] = useState<FlagState>("normal");
-	const previousFlag = useRef(flag);
 
-	const loadRecords = useCallback(
-		async (domainQuery: string | undefined) => {
+	useEffect(() => {
+		let ignoreResult = false;
+
+		async function loadRecords() {
+			setIsLoading(true);
 			const { filteredRecords, newFlag } = await fetchDomainResults(
 				domainQuery,
 				null,
 				"normal",
 			);
+
+			if (ignoreResult) return;
+
 			const initialState = buildInitialSearchState(filteredRecords, newFlag);
 
 			setFlag(initialState.flag);
 			setRecords(initialState.records);
 			setCursor(initialState.cursor);
 			setIsLoading(false);
-		},
-		[setIsLoading],
-	);
+		}
 
-	useEffect(() => {
-		setIsLoading(true);
-		loadRecords(domainQuery);
-	}, [domainQuery, loadRecords, setIsLoading]);
+		loadRecords();
+
+		return () => {
+			ignoreResult = true;
+		};
+	}, [domainQuery, setIsLoading]);
+
+	const appendRecords = useCallback((filteredRecords: RecordWithSelector[]) => {
+		setRecords((currentRecords) => {
+			const updatedRecordsMap = new Map(currentRecords);
+			for (const record of filteredRecords) {
+				if (!updatedRecordsMap.has(record.id)) {
+					updatedRecordsMap.set(record.id, record);
+				}
+			}
+			return updatedRecordsMap;
+		});
+	}, []);
 
 	const loadMore = useCallback(async () => {
 		if (flag === "stop" || (!cursor && flag === "normal")) return;
@@ -98,31 +115,34 @@ function DomainSearchResults({
 		const lastCursor = filteredRecords[filteredRecords.length - 1]?.id;
 
 		if (filteredRecords.length === 0 || lastCursor === cursor) {
-			// If no new records are found, stop further loading
+			if (flag === "normal") {
+				const { filteredRecords: modifiedRecords } = await fetchDomainResults(
+					domainQuery,
+					null,
+					"modified",
+				);
+				const modifiedCursor = modifiedRecords[modifiedRecords.length - 1]?.id;
+
+				if (modifiedRecords.length === 0) {
+					setCursor(null);
+					setFlag("stop");
+					return;
+				}
+
+				appendRecords(modifiedRecords);
+				setCursor(modifiedCursor ?? null);
+				setFlag("modified");
+				return;
+			}
+
 			setCursor(null);
-			setFlag((oldFlag) => (oldFlag === "normal" ? "modified" : "stop"));
+			setFlag("stop");
 			return;
 		}
 
-		setRecords((currentRecords) => {
-			const updatedRecordsMap = new Map(currentRecords);
-			for (const record of filteredRecords) {
-				if (!updatedRecordsMap.has(record.id)) {
-					updatedRecordsMap.set(record.id, record);
-				}
-			}
-			return updatedRecordsMap;
-		});
-
+		appendRecords(filteredRecords);
 		setCursor(lastCursor);
-	}, [cursor, domainQuery, flag]);
-
-	useEffect(() => {
-		if (previousFlag.current === flag) return;
-
-		previousFlag.current = flag;
-		loadMore();
-	}, [flag, loadMore]);
+	}, [appendRecords, cursor, domainQuery, flag]);
 
 	return isLoading ? (
 		<Loading />

--- a/src/components/domainSearchState.test.ts
+++ b/src/components/domainSearchState.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "vitest";
+import type { RecordWithSelector } from "../lib/db";
+import { buildInitialSearchState } from "./domainSearchState";
+
+function record(id: number): RecordWithSelector {
+	return { id } as RecordWithSelector;
+}
+
+test("clears stale records when a fresh search returns no results", () => {
+	const previousRecords = new Map([[1, record(1)]]);
+
+	const state = buildInitialSearchState([], "normal");
+
+	expect(state.records).not.toBe(previousRecords);
+	expect(state.records.size).toBe(0);
+	expect(state.cursor).toBeNull();
+	expect(state.flag).toBe("stop");
+});
+
+test("replaces stale records with the fresh search results", () => {
+	const previousRecords = new Map([[1, record(1)]]);
+
+	const state = buildInitialSearchState([record(2), record(3)], "modified");
+
+	expect(state.records).not.toBe(previousRecords);
+	expect(Array.from(state.records.keys())).toStrictEqual([2, 3]);
+	expect(state.cursor).toBe(3);
+	expect(state.flag).toBe("modified");
+});

--- a/src/components/domainSearchState.test.ts
+++ b/src/components/domainSearchState.test.ts
@@ -7,22 +7,16 @@ function record(id: number): RecordWithSelector {
 }
 
 test("clears stale records when a fresh search returns no results", () => {
-	const previousRecords = new Map([[1, record(1)]]);
-
 	const state = buildInitialSearchState([], "normal");
 
-	expect(state.records).not.toBe(previousRecords);
 	expect(state.records.size).toBe(0);
 	expect(state.cursor).toBeNull();
 	expect(state.flag).toBe("stop");
 });
 
 test("replaces stale records with the fresh search results", () => {
-	const previousRecords = new Map([[1, record(1)]]);
-
 	const state = buildInitialSearchState([record(2), record(3)], "modified");
 
-	expect(state.records).not.toBe(previousRecords);
 	expect(Array.from(state.records.keys())).toStrictEqual([2, 3]);
 	expect(state.cursor).toBe(3);
 	expect(state.flag).toBe("modified");

--- a/src/components/domainSearchState.ts
+++ b/src/components/domainSearchState.ts
@@ -1,0 +1,33 @@
+import type { RecordWithSelector } from "../lib/db";
+
+export type FlagState = "normal" | "modified" | "stop";
+
+interface InitialSearchState {
+	records: Map<number, RecordWithSelector>;
+	cursor: number | null;
+	flag: FlagState;
+}
+
+export function buildInitialSearchState(
+	filteredRecords: RecordWithSelector[],
+	newFlag: FlagState,
+): InitialSearchState {
+	if (filteredRecords.length === 0) {
+		return {
+			records: new Map(),
+			cursor: null,
+			flag: "stop",
+		};
+	}
+
+	const records = new Map<number, RecordWithSelector>();
+	for (const record of filteredRecords) {
+		records.set(record.id, record);
+	}
+
+	return {
+		records,
+		cursor: filteredRecords[filteredRecords.length - 1]?.id ?? null,
+		flag: newFlag,
+	};
+}


### PR DESCRIPTION
## Summary

- replace the first-page search state with a fresh records map for each new query
- clear the cursor and stop pagination when a fresh query returns no records
- add regression coverage for empty and replacement search-result state

Fixes #169.

## Validation

- `pnpm install --frozen-lockfile --ignore-scripts --config.engine-strict=false`
- `pnpm exec prisma generate --generator client_js`
- `pnpm exec vitest run src/components/domainSearchState.test.ts`
- `pnpm exec biome ci src/components/DomainSearchResults.tsx src/components/domainSearchState.ts src/components/domainSearchState.test.ts`
- `pnpm exec tsc --noEmit`
- `git diff --check`

## Notes

- Local `pnpm test` still fails in the existing `src/lib/selector_guesser.test.ts` date expectations (`20241122` expected, `20241121` received). The new regression test passes.
- The local machine is currently running Node v24.2.0 even though the repo requests Node 22, so I used `--config.engine-strict=false` for local pnpm commands.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added new test coverage for search state initialization logic.

* **Refactor**
  * Improved domain search results component's internal state management and pagination handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/zkemail/archive.zk.email/pull/191?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->