### PR TITLE
Sort DKIM search results

### DIFF
--- a/src/components/DomainSearchResultsDisplay.tsx
+++ b/src/components/DomainSearchResultsDisplay.tsx
@@ -1,49 +1,56 @@
 "use client";
 import type { RecordWithSelector } from "@/lib/db";
 import type React from "react";
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useInView } from "react-intersection-observer";
 import { SelectorResult } from "./SelectorResult";
+import { sortRecordsForDisplay } from "./sortRecordsForDisplay";
 
 interface DomainSearchResultProps {
-  domainQuery: string | undefined;
-  records: Map<number, RecordWithSelector>;
-  loadMore: () => void;
-  cursor: number | null;
+	domainQuery: string | undefined;
+	records: Map<number, RecordWithSelector>;
+	loadMore: () => void;
+	cursor: number | null;
 }
 
 export const DomainSearchResultsDisplay: React.FC<DomainSearchResultProps> = ({
-  domainQuery,
-  records,
-  loadMore,
-  cursor,
+	domainQuery,
+	records,
+	loadMore,
+	cursor,
 }) => {
-  const { ref: inViewElement, inView } = useInView();
+	const { ref: inViewElement, inView } = useInView();
+	const sortedRecords = useMemo(
+		() => sortRecordsForDisplay(records.values()),
+		[records],
+	);
 
-  useEffect(() => {
-    if (inView) {
-      loadMore();
-    }
-  }, [inView]);
+	// loadMore is intentionally omitted so the sentinel does not refetch on every parent render.
+	// biome-ignore lint/correctness/useExhaustiveDependencies: loadMore is intentionally render-unstable.
+	useEffect(() => {
+		if (inView) {
+			loadMore();
+		}
+	}, [inView]);
 
-  if (!domainQuery) {
-    return <div>Enter a search term</div>;
-  }
-  if (!Array.from(records.values())?.length) {
-    return <div>No records found for "{domainQuery}"</div>;
-  }
-  return (
-    <div>
-      <p>
-        Search results for <b>{domainQuery}</b>
-      </p>
-      <div>
-        {Array.from(records.values()).map((record) => (
-          <SelectorResult key={record.id} record={record} />
-        ))}
-      </div>
-      {!cursor && <p>No more records</p>}
-      <div ref={inViewElement} />
-    </div>
-  );
+	if (!domainQuery) {
+		return <div>Enter a search term</div>;
+	}
+	if (!sortedRecords.length) {
+		return <div>No records found for "{domainQuery}"</div>;
+	}
+	return (
+		<div>
+			<p>
+				Search results for <b>{domainQuery}</b>
+			</p>
+			<div>
+				{sortedRecords.map((record) => (
+					<SelectorResult key={record.id} record={record} />
+				))}
+			</div>
+			{!cursor && <p>No more records</p>}
+			<div ref={inViewElement} />
+		</div>
+	);
 };

--- a/src/components/sortRecordsForDisplay.test.ts
+++ b/src/components/sortRecordsForDisplay.test.ts
@@ -1,0 +1,42 @@
+import type { RecordWithSelector } from "@/lib/db";
+import { expect, test } from "vitest";
+import { sortRecordsForDisplay } from "./sortRecordsForDisplay";
+
+function record(
+	id: number,
+	domain: string,
+	selector: string,
+	firstSeenAt: string,
+	lastSeenAt: string | null,
+): RecordWithSelector {
+	return {
+		id,
+		firstSeenAt: new Date(firstSeenAt),
+		lastSeenAt: lastSeenAt ? new Date(lastSeenAt) : null,
+		domainSelectorPair: {
+			domain,
+			selector,
+		},
+	} as RecordWithSelector;
+}
+
+test("sorts DKIM records deterministically by domain, selector, and newest seen dates", () => {
+	const sorted = sortRecordsForDisplay([
+		record(4, "sub.example.com", "alpha", "2024-01-01", "2024-01-01"),
+		record(2, "example.com", "beta", "2024-01-01", "2024-01-01"),
+		record(1, "example.com", "alpha", "2024-01-01", "2024-01-03"),
+		record(3, "example.com", "alpha", "2024-01-01", "2024-01-05"),
+	]);
+
+	expect(sorted.map((item) => item.id)).toStrictEqual([3, 1, 2, 4]);
+});
+
+test("uses first seen and id as stable tie-breakers when last seen is absent", () => {
+	const sorted = sortRecordsForDisplay([
+		record(3, "example.com", "alpha", "2024-01-01", null),
+		record(1, "example.com", "alpha", "2024-01-03", null),
+		record(2, "example.com", "alpha", "2024-01-03", null),
+	]);
+
+	expect(sorted.map((item) => item.id)).toStrictEqual([1, 2, 3]);
+});

--- a/src/components/sortRecordsForDisplay.ts
+++ b/src/components/sortRecordsForDisplay.ts
@@ -1,0 +1,49 @@
+import type { RecordWithSelector } from "@/lib/db";
+
+function compareText(a: string | undefined, b: string | undefined): number {
+	return (a ?? "").localeCompare(b ?? "", undefined, {
+		numeric: true,
+		sensitivity: "base",
+	});
+}
+
+function dateToTimestamp(date: Date | string | null | undefined): number {
+	if (!date) return Number.NEGATIVE_INFINITY;
+
+	const timestamp =
+		date instanceof Date ? date.getTime() : new Date(date).getTime();
+	return Number.isNaN(timestamp) ? Number.NEGATIVE_INFINITY : timestamp;
+}
+
+function compareDatesDescending(
+	a: Date | string | null | undefined,
+	b: Date | string | null | undefined,
+): number {
+	return dateToTimestamp(b) - dateToTimestamp(a);
+}
+
+export function sortRecordsForDisplay(
+	records: Iterable<RecordWithSelector>,
+): RecordWithSelector[] {
+	return Array.from(records).sort((a, b) => {
+		const domainOrder = compareText(
+			a.domainSelectorPair?.domain,
+			b.domainSelectorPair?.domain,
+		);
+		if (domainOrder) return domainOrder;
+
+		const selectorOrder = compareText(
+			a.domainSelectorPair?.selector,
+			b.domainSelectorPair?.selector,
+		);
+		if (selectorOrder) return selectorOrder;
+
+		const lastSeenOrder = compareDatesDescending(a.lastSeenAt, b.lastSeenAt);
+		if (lastSeenOrder) return lastSeenOrder;
+
+		const firstSeenOrder = compareDatesDescending(a.firstSeenAt, b.firstSeenAt);
+		if (firstSeenOrder) return firstSeenOrder;
+
+		return a.id - b.id;
+	});
+}


### PR DESCRIPTION
## Summary
- Sort DKIM records before rendering search results so the UI is deterministic
- Order by domain, selector, newest last-seen date, newest first-seen date, then id
- Add focused tests for the display sort order

Fixes #173

## Testing
- pnpm vitest run src/components/sortRecordsForDisplay.test.ts
- pnpm exec biome check src/components/DomainSearchResultsDisplay.tsx src/components/sortRecordsForDisplay.ts src/components/sortRecordsForDisplay.test.ts
- pnpm exec tsc --noEmit
- git diff --check