### PR TITLE
Fix About and Contribute internal navigation

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,17 +1,41 @@
 import { prisma } from "@/lib/db";
+import Link from "next/link";
 import React from "react";
 
 export const revalidate = 60;
 
+type ArchiveStats =
+	| {
+			available: true;
+			uniqueDomains: string;
+			uniqueSelectors: string;
+			domainSelectorPairs: number;
+			dkimKeys: number;
+	  }
+	| { available: false };
+
+async function getArchiveStats(): Promise<ArchiveStats> {
+	try {
+		// https://github.com/prisma/prisma/issues/4228
+		type CountResult = [{ count: bigint }];
+		const [uniqueDomainsCount] = await prisma.$queryRaw`SELECT COUNT(DISTINCT domain) FROM "DomainSelectorPair";` as CountResult;
+		const [uniqueSelectorsCount] = await prisma.$queryRaw`SELECT COUNT(DISTINCT selector) FROM "DomainSelectorPair";` as CountResult;
+
+		return {
+			available: true,
+			uniqueDomains: uniqueDomainsCount.count.toString(),
+			uniqueSelectors: uniqueSelectorsCount.count.toString(),
+			domainSelectorPairs: await prisma.domainSelectorPair.count(),
+			dkimKeys: await prisma.dkimRecord.count(),
+		};
+	} catch (error) {
+		console.error("Failed to load archive statistics", error);
+		return { available: false };
+	}
+}
+
 export default async function Page() {
-
-	// https://github.com/prisma/prisma/issues/4228
-	type CountResult = [{ count: bigint }]
-	const [uniqueDomainsCount] = await prisma.$queryRaw`SELECT COUNT(DISTINCT domain) FROM "DomainSelectorPair";` as CountResult;
-	const [uniqueSelectorsCount] = await prisma.$queryRaw`SELECT COUNT(DISTINCT selector) FROM "DomainSelectorPair";` as CountResult;
-
-	const domainSelectorPairCount = await prisma.domainSelectorPair.count();
-	const dkimKeyCount = await prisma.dkimRecord.count();
+	const stats = await getArchiveStats();
 
 	return (
 		<div>
@@ -21,7 +45,7 @@ export default async function Page() {
 				The site is a part of the <a href="https://prove.email/">Proof of Email</a> project.
 			</p>
 			<p>
-				On the <a href="contribute">Contribute</a> page, users can contribute with new domains and selectors,
+				On the <Link href="/contribute">Contribute</Link> page, users can contribute with new domains and selectors,
 				which are extracted from the DKIM-Signature header field in each email message in the user's Gmail account.
 				When domains and selectors are added, the site fetches the DKIM key via DNS and stores it in the database.
 			</p>
@@ -30,18 +54,16 @@ export default async function Page() {
 			</p>
 
 			<h2>Statistics</h2>
-			<p>
-				Unique domains: {uniqueDomainsCount.count.toString()}
-			</p>
-			<p>
-				Unique selectors: {uniqueSelectorsCount.count.toString()}
-			</p>
-			<p>
-				Domain/selector-pairs: {domainSelectorPairCount}
-			</p>
-			<p>
-				DKIM keys: {dkimKeyCount}
-			</p>
+			{stats.available ? (
+				<>
+					<p>Unique domains: {stats.uniqueDomains}</p>
+					<p>Unique selectors: {stats.uniqueSelectors}</p>
+					<p>Domain/selector-pairs: {stats.domainSelectorPairs}</p>
+					<p>DKIM keys: {stats.dkimKeys}</p>
+				</>
+			) : (
+				<p>Archive statistics are temporarily unavailable.</p>
+			)}
 		</div >
 	)
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,7 @@
 import DomainSearchResults from "@/components/DomainSearchResults";
 import { SearchInput } from "@/components/SearchInput";
 import { JWKArchiveDisplayList } from "@/components/JWKArchiveDisplay";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useState, useEffect } from "react";
 
@@ -55,7 +56,7 @@ export default function Home() {
       <div style={{ textAlign: "center", marginTop: "5rem", fontSize: "0.8rem" }}>
         <hr style={{ width: "50%", margin: "1rem auto", borderTop: "1px solid black" }} />
         <div>
-          <a href="about">About</a> this site
+          <Link href="/about">About</Link> this site
         </div>
         <div>
           Visit the project on <a href="https://github.com/zkemail/archive.prove.email">GitHub</a>
@@ -64,13 +65,13 @@ export default function Home() {
           Visit <a href="https://prove.email/">Proof of Email</a>
         </div>
         <div>
-          <a href="contribute">Contribute</a> to the archive
+          <Link href="/contribute">Contribute</Link> to the archive
         </div>
         <div>
-          Explore the <a href="api-explorer">API</a>
+          Explore the <Link href="/api-explorer">API</Link>
         </div>
         <div>
-          Read the <a href="privacy-policy">Privacy policy</a>
+          Read the <Link href="/privacy-policy">Privacy policy</Link>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Normalize homepage footer navigation to use Next.js `Link` with root-relative internal routes (`/about`, `/contribute`, `/api-explorer`, `/privacy-policy`) so the current deployment host is preserved.
- Normalize the About page Contribute link to `/contribute`.
- Let the About page render a fallback when archive statistics cannot be loaded, instead of failing the whole route.

Fixes #183.
Fixes #184.

## Validation
- `git diff --check`
- Searched `src` for stale internal relative links: `href=about`, `href=contribute`, `href=api-explorer`, `href=privacy-policy`
- `pnpm exec prisma generate --generator client_js`
- `pnpm check-types` passed on Node v24.16.0; the project warns that it expects Node `^22.0.0`

## Notes
- `pnpm lint` was not run to completion because `next lint` prompts to initialize ESLint config in this repo.
- I could not verify the current Render deployment directly because the live `archive-58ub.onrender.com` routes currently return 404; this PR validates and fixes the source routes/links.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Archive statistics now include comprehensive error handling, gracefully displaying a "temporarily unavailable" message when statistics data fails to load, preventing error states and improving overall application reliability and user experience.

* **Improvements**
  * Optimized and enhanced internal navigation links throughout the application for improved routing consistency, performance optimization, and a better overall user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->