### PR TITLE
Clarify Gmail access checkbox on contribute page

### DIFF
--- a/src/app/contribute/page.tsx
+++ b/src/app/contribute/page.tsx
@@ -22,6 +22,14 @@ export default function Page() {
 			<h3>Upload from Gmail</h3>
 			<p>To upload directly from your Gmail account, visit the <strong><a href="#" onClick={() => signIn("google")}>Upload from Gmail</a></strong> page.</p>
 			<p>
+				During Google's sign-in flow, make sure you tick the checkbox that grants access to read your Gmail messages.
+				If you leave that checkbox unchecked, DKIM Archive will not be able to scan your messages for
+				<InlineCode>DKIM-Signature</InlineCode> headers, and the Gmail upload will not find domains and selectors to contribute.
+			</p>
+			<p>
+				Only continue if you are comfortable granting that Gmail access. You can revoke the permission later from your Google account settings.
+			</p>
+			<p>
 				When you sign in with your Gmail account and press Start, the site will
 				extract the <InlineCode>DKIM-Signature</InlineCode> field from each email message in your Gmail account.
 				A signature can look something like this:


### PR DESCRIPTION
## Summary
- Adds explicit guidance on the Contribute page telling Gmail upload users to tick the Google consent checkbox that grants access to read Gmail messages.
- Explains that leaving the checkbox unchecked prevents DKIM Archive from scanning messages for DKIM-Signature headers.
- Adds a short reminder that users should only continue if they are comfortable granting access and can revoke permission later.

## Issue
Closes #132

## Verification
- git diff --check passed locally.
- Attempted 
px pnpm install --frozen-lockfile; npx pnpm run check-types, but dependency/type-check execution timed out in the local Windows environment.
- Attempted 
px pnpm exec tsc --noEmit --pretty false, but it also timed out locally.

## Note
I did not capture or include a Google OAuth screenshot because that would require entering the live Google authorization flow. This PR covers the requested instruction text in a public-safe way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced the "Upload from Gmail" section with clearer guidance. Added warnings about the Google sign-in checkbox requirement to enable DKIM scanning, explained consequences of not granting permissions, and clarified that users can revoke access anytime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->